### PR TITLE
Hot fix for Unity Mac Player

### DIFF
--- a/EdgeMultiplay/Scripts/EdgeManager.cs
+++ b/EdgeMultiplay/Scripts/EdgeManager.cs
@@ -166,6 +166,12 @@ namespace EdgeMultiplay
             {
                 udpClient.Dispose();
             }
+            if(Application.platform == RuntimePlatform.OSXPlayer
+               || Application.platform == RuntimePlatform.WindowsPlayer
+               || Application.platform == RuntimePlatform.LinuxPlayer)
+            {
+                Environment.Exit(0);
+            }
         }
 
         #endregion

--- a/EdgeMultiplay/Scripts/EdgeManager.cs
+++ b/EdgeMultiplay/Scripts/EdgeManager.cs
@@ -166,7 +166,7 @@ namespace EdgeMultiplay
             {
                 udpClient.Dispose();
             }
-            if(Application.platform == RuntimePlatform.OSXPlayer
+            if (Application.platform == RuntimePlatform.OSXPlayer
                || Application.platform == RuntimePlatform.WindowsPlayer
                || Application.platform == RuntimePlatform.LinuxPlayer)
             {


### PR DESCRIPTION
On (Windows, Mac, Linux players)  Exit App at EdgeManager (OnDestroy)