### PR TITLE
DestroyOnLoad Option

### DIFF
--- a/EdgeMultiplay/Scripts/EdgeManager.cs
+++ b/EdgeMultiplay/Scripts/EdgeManager.cs
@@ -440,18 +440,34 @@ namespace EdgeMultiplay
     /// </summary>
     public static void Disconnect()
     {
-      wsClient = null;
-      udpClient = null;
-      foreach (NetworkedPlayer player in currentRoomPlayers)
+      if (wsClient != null)
       {
-        Destroy(player.gameObject);
+        wsClient.Dispose();
+        wsClient = null;
       }
-      currentRoomPlayers = new List<NetworkedPlayer>();
-      gameSession = new Session();
+      if (udpClient != null)
+      {
+        udpClient.Dispose();
+        udpClient = null;
+      }
+      if (integration != null)
+      {
+        integration.Dispose();
+        integration = null;
+      }
+      if (currentRoomPlayers != null)
+      {
+        foreach (NetworkedPlayer player in currentRoomPlayers)
+        {
+          Destroy(player.gameObject);
+        }
+      }
+      currentRoomPlayers = null;
+      gameSession = null;
       gameStarted = false;
       MessageSender = null;
       localPlayer = null;
-      observers = new List<EdgeMultiplayObserver>();
+      observers = null;
     }
 
     /// <summary>

--- a/EdgeMultiplay/Scripts/EdgeManager.cs
+++ b/EdgeMultiplay/Scripts/EdgeManager.cs
@@ -97,7 +97,7 @@ namespace EdgeMultiplay
     #endregion
 
     #region MonoBehaviour Callbacks
-    private void OnEnable()
+    private void Awake()
     {
       if (!DestroyOnLoad)
       {


### PR DESCRIPTION
* DestroyOnLoad option to allow destroying EdgeManager (MatchMaking Manager) in case of scene transition.
>Default is false (Don't Destroy EdgeManager on Scene transition)

* Assigning EdgeManager variables only in Monobehaviour callback  Awake

* Move WorldOriginTransform to its correct region.

* Removing hotfix of application stuck on exit resolved by https://github.com/mobiledgex/edge-cloud-sdk-unity/pull/203
<img width="380" alt="Screen Shot 2022-01-27 at 10 20 17 AM" src="https://user-images.githubusercontent.com/24863504/151420028-af92e6d0-7b88-4cd8-bec2-9590b72b918f.png">
